### PR TITLE
Restrict what weapons can be given to players

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/weaponcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/weaponcore.lua
@@ -2,14 +2,14 @@ E2Lib.RegisterExtension("weaponcore", true)
 
 local sbox_E2_Dmg_Adv = CreateConVar("sbox_E2_WeaponCore_allow_all_users", "0", FCVAR_ARCHIVE)
 
-local function giveSwep(ply, weaponClass)
+local function giveSwep(ply, setter, weaponClass)
 	if not ply:Alive() then return end
 
 	-- Make sure this is a SWEP
 	local swep = list.Get("Weapon")[weaponClass]
 	if not swep then return end
 
-	local isAdmin = ply:IsAdmin() or game.SinglePlayer()
+	local isAdmin = setter:IsAdmin() or game.SinglePlayer()
 	if (not swep.Spawnable and not isAdmin) or (swep.AdminOnly and not isAdmin) then
 		return
 	end
@@ -78,7 +78,7 @@ e2function void entity:plyGive(string weaponClass)
 	if not ValidPly(this) then return self:throw("Invalid player", nil) end
 	if not hasAccess(self.player, this) then return self:throw("You do not have access", nil) end
 
-	giveSwep(this, weaponClass)
+	giveSwep(this, self.player, weaponClass)
 end
 
 --- Give the player a weapon.
@@ -86,7 +86,7 @@ e2function void entity:plyGiveWeapon(string weaponClass)
 	if not ValidPly(this) then return self:throw("Invalid player", nil) end
 	if not hasAccess(self.player, this) then return self:throw("You do not have access", nil) end
 
-	giveSwep(this, weaponClass)
+	giveSwep(this, self.player, weaponClass)
 end
 
 --- Gives ammo to a player.

--- a/lua/entities/gmod_wire_expression2/core/custom/weaponcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/weaponcore.lua
@@ -1,6 +1,22 @@
 E2Lib.RegisterExtension("weaponcore", true)
 
-local sbox_E2_Dmg_Adv = CreateConVar( "sbox_E2_WeaponCore_allow_all_users", "0", FCVAR_ARCHIVE )
+local sbox_E2_Dmg_Adv = CreateConVar("sbox_E2_WeaponCore_allow_all_users", "0", FCVAR_ARCHIVE)
+
+local function giveSwep(ply, weaponClass)
+	if not ply:Alive() then return end
+
+	-- Make sure this is a SWEP
+	local swep = list.Get("Weapon")[weaponClass]
+	if not swep then return end
+
+	if not gamemode.Call("PlayerGiveSWEP", ply, weaponClass, swep) then return end
+
+	if not ply:HasWeapon(swep.ClassName) then
+		ply:Give(swep.ClassName)
+	end
+
+	ply:SelectWeapon(swep.ClassName)
+end
 
 local function isFriend(owner, player)
 	if owner == player then
@@ -20,7 +36,7 @@ local function isFriend(owner, player)
     end
 end
 
-local function ValidPly( ply )
+local function ValidPly(ply)
 	if not ply or not ply:IsValid() or not ply:IsPlayer() then
 		return false
 	end
@@ -57,7 +73,7 @@ e2function void entity:plyGive(string weaponClass)
 	if not ValidPly(this) then return self:throw("Invalid player", nil) end
 	if not hasAccess(self.player, this) then return self:throw("You do not have access", nil) end
 
-	this:Give(weaponClass)
+	giveSwep(this, weaponClass)
 end
 
 --- Give the player a weapon.
@@ -65,7 +81,7 @@ e2function void entity:plyGiveWeapon(string weaponClass)
 	if not ValidPly(this) then return self:throw("Invalid player", nil) end
 	if not hasAccess(self.player, this) then return self:throw("You do not have access", nil) end
 
-	this:Give(weaponClass)
+	giveSwep(this, weaponClass)
 end
 
 --- Gives ammo to a player.

--- a/lua/entities/gmod_wire_expression2/core/custom/weaponcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/weaponcore.lua
@@ -9,6 +9,11 @@ local function giveSwep(ply, weaponClass)
 	local swep = list.Get("Weapon")[weaponClass]
 	if not swep then return end
 
+	local isAdmin = ply:IsAdmin() or game.SinglePlayer()
+	if (not swep.Spawnable and not isAdmin) or (swep.AdminOnly and not isAdmin) then
+		return
+	end
+
 	if not gamemode.Call("PlayerGiveSWEP", ply, weaponClass, swep) then return end
 
 	if not ply:HasWeapon(swep.ClassName) then


### PR DESCRIPTION
Currently, the two PlyGive functions let players spawn ANY entity, including non-weapons.